### PR TITLE
Fix missing key attribute for JAX models

### DIFF
--- a/src/models/dpendulum.py
+++ b/src/models/dpendulum.py
@@ -611,8 +611,11 @@ class DoublePendulum(Pendulum):
         _ = self.backend.U0
         params['not_inherited'] = False
         super().__init__(params)
-        # Initialize a JAX PRNG key for random operations
-        self._jax_key = jax.random.PRNGKey(0)
+        # Initialize JAX PRNG keys for random operations. `self.key` is used
+        # by methods such as `select_initial`, while `_jax_key` remains for
+        # legacy routines that still expect this name.
+        self.key = jax.random.PRNGKey(0)
+        self._jax_key = self.key
 
     def make_eqs_motion(self, params: dict = None):
         def eqs_motion(t, x, params):

--- a/src/models/pendulum.py
+++ b/src/models/pendulum.py
@@ -22,8 +22,13 @@ class Pendulum(BaseModel):
             self.l = params.get('l', 1.0)
             self.m = params.get('m', 0.1)
             self.k_f = params.get('k_f', 0.0)
-        
+
         super().__init__(params)
+
+        # Initialize a JAX PRNG key used for sampling initial conditions
+        # This attribute is accessed in `select_initial`, hence it must
+        # exist before that method runs.
+        self.key = jax.random.PRNGKey(0)
 
     def get_initial_state(self, params: dict = None) -> dict:
         """


### PR DESCRIPTION
## Summary
- initialize `self.key` in `Pendulum` and `DoublePendulum`
- keep `_jax_key` for backward compatibility

## Testing
- `python - <<'PY'
import src
PY`

The above fails due to missing third-party dependencies (e.g., gymnasium).

------
https://chatgpt.com/codex/tasks/task_e_68726d7442ac83279e00c4b49a5325ca