### PR TITLE
Fix initialization error in DoublePendulum

### DIFF
--- a/src/models/dpendulum.py
+++ b/src/models/dpendulum.py
@@ -440,11 +440,10 @@ class DoublePendulum(Pendulum):
         if self.key is None:
             self.key = jax.random.PRNGKey(0)
 
-        # Get symbolic representation of potential energy
-        temp_state = self.symbolic.get_potential_energy_symbols()
-
-        # Get initial conditions by calling the appropriate select_initial method
-        x_0, dq_0 = self.select_initial(params, temp_state)
+        # `select_initial` does not rely on any symbolic backend anymore.
+        # It only uses PRNG keys stored on the instance, so we simply pass
+        # an empty state dictionary for API compatibility.
+        x_0, dq_0 = self.select_initial(params, {})
 
         # Concatenate position and velocity to form the full state vector
         return jnp.concatenate([x_0, dq_0])


### PR DESCRIPTION
## Summary
- remove stale symbolic call in `DoublePendulum.get_initial_state`
- keep initial state selection purely JAX based

## Testing
- `pytest -q`
- `python - <<'PY'
from src.models.dpendulum import DoublePendulum
m = DoublePendulum({'state_size':4,'num_dof':2, 'delta_t':0.02, 'k_f':0.0, 'not_inherited':False})
print('init done')
print(m.get_initial_state({'mode':'speed','E_d':0.5}))
PY`

------
https://chatgpt.com/codex/tasks/task_e_687271a8f5808327992918290e3ec7f0