### PR TITLE
Fix None energy

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,7 +7,7 @@ register(
     entry_point="src.learning.gym_environment:BaseGymEnvironment",
     kwargs={
         "render": False,
-        "energy_command": None,
+        "energy_command": 0.0,
         "mode": 'random_des',
         "solve": False,
     },

--- a/src/environments/base_environments.py
+++ b/src/environments/base_environments.py
@@ -118,6 +118,7 @@ class BaseEnvironment(ABC):
         return step_bool
 
     def restart(self, params: dict = None):
+        params = params or {}
         p_0 = self.model.restart({'mode': self.mode, 'E_d': params.get('E_d', 0)})
         self.controller.restart()
         self.generator.restart({'x_0': p_0})

--- a/src/learning/gym_environment.py
+++ b/src/learning/gym_environment.py
@@ -86,7 +86,8 @@ class BaseGymEnvironment(gym.Env):
         # --- Energy and Inference Setup ---
         self.energy_step = kwargs.get('energy_step', False)
         self.inference = 'energy_command' in kwargs
-        self.E_d = kwargs.get('energy_command', 0.0)
+        energy_cmd = kwargs.get('energy_command', 0.0)
+        self.E_d = 0.0 if energy_cmd is None else energy_cmd
         self.energy_observer = kwargs.get('energy_observer')
 
         # --- System and Action Space Configuration ---

--- a/src/models/dpendulum.py
+++ b/src/models/dpendulum.py
@@ -462,6 +462,8 @@ class DoublePendulum(Pendulum):
         params = params if params is not None else {}
         mode = params.get('mode', 'equilibrium')
         E_d = params.get('E_d', 0)
+        if E_d is None:
+            E_d = 0
 
         # Split the key for all random operations in this function
         self._jax_key, key_alpha, key_beta = jax.random.split(self._jax_key, 3)


### PR DESCRIPTION
## Summary
- avoid None when energy_command not provided
- guard against None in dpendulum energy setup
- handle missing params in environment restart
- use 0.0 as default energy_command in env registration

## Testing
- `python -m compileall -q src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687273c5c3e8832797f190c052ea4559