### PR TITLE
Fix None energy for initial state

### DIFF
--- a/src/models/dpendulum.py
+++ b/src/models/dpendulum.py
@@ -494,7 +494,9 @@ class DoublePendulum(Pendulum):
         # --- Main function logic ---
         params = params if params is not None else {}
         mode = params.get('mode', 'equilibrium')
-        E_d = params.get('E_d', 0.0)
+        # Some callers may set ``E_d`` explicitly to ``None``.
+        # Ensure it is always a valid numeric value for the optimizer.
+        E_d = params.get('E_d') or 0.0
         
         key, key_alpha, key_beta = jax.random.split(state['jax_key'], 3)
         alpha = jax.random.uniform(key_alpha)
@@ -675,7 +677,8 @@ class DoublePendulum(Pendulum):
         # --- Main function logic ---
         params = params if params is not None else {}
         mode = params.get('mode', 'equilibrium')
-        E_d = params.get('E_d', 0.0)
+        # ``E_d`` might explicitly be ``None`` when no energy command is used.
+        E_d = params.get('E_d') or 0.0
 
         # Use the instance's PRNG key and split it for use.
         key, key_alpha, key_beta = jax.random.split(self.key, 3)

--- a/src/models/pendulum.py
+++ b/src/models/pendulum.py
@@ -105,7 +105,9 @@ class Pendulum(BaseModel):
         """
         params = params or {}
         mode = params.get('mode', 'equilibrium')
-        E_d = params.get('E_d', 0.0)
+        # ``E_d`` may be explicitly ``None`` when training without an energy
+        # command. Fall back to ``0.0`` in that case.
+        E_d = params.get('E_d') or 0.0
         key = self.key # Use the key from the model's state
 
         # Split PRNG key for reproducible randomness

--- a/src/models/snake.py
+++ b/src/models/snake.py
@@ -92,7 +92,8 @@ class Snake(BaseModel):
 
         # Handle inputs
         mode = params.get('mode', 'equilibrium')
-        E_d = params.get('E_d', 0)
+        # ``E_d`` can be explicitly ``None`` when no energy schedule is used.
+        E_d = params.get('E_d') or 0
 
         # Choose energies based on mode
         alpha = self.rng.uniform(0, 1)


### PR DESCRIPTION
## Summary
- guard against `None` energy values when selecting initial state
- ensure all models fall back to 0 energy if `E_d` is missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687277160b2c832793a64147aef3fdef